### PR TITLE
converted var to const for more efficiency

### DIFF
--- a/scripts/HelloWorld.js
+++ b/scripts/HelloWorld.js
@@ -6,8 +6,8 @@
     - Express.js (built-in, https://www.npmjs.com/package/express)
 */
 
-var express = require('express');
-var router = express.Router();
+const  express = require('express');
+const  router = express.Router();
 
 
 router.get('/', function(req, res, next) {


### PR DESCRIPTION
converted var to const for constant value which cannot be change when we declared same name variable it will give an error which cant be in var clause